### PR TITLE
ci: defining the default labels configuration

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,78 @@
+# Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+# Licensed under the MIT license.
+
+# This file is used to declaratively define the GitHub repository default labels.
+# Documentation: https://github.com/Financial-Times/github-label-sync/#label-config-file
+
+# Generic labels
+- name: bug
+  color: B60205
+  description: Something isn't working
+- name: database
+  color: 097BA1
+  description: The database tools
+- name: dependencies
+  color: 0366D6
+  description: Pull requests that update a dependency file
+- name: deployment
+  color: D45E0E
+  description: Kubernetes deployment configuration
+- name: dev
+  color: 0E8A16
+  description: Tools for helping development
+- name: documentation
+  color: 0075CA
+  description: Improvements or additions to documentation
+- name: done
+  color: 1D76DB
+  description: I can say it's finished
+- name: duplicate
+  color: CFD3D7
+  description: This issue or pull request already exists
+- name: enhancement
+  color: A2EEEF
+  description: New feature or request
+- name: epic
+  color: FF7800
+  description: This is a cool idea
+- name: feature
+  color: 67AF00
+  description: New features ideas
+- name: help wanted
+  color: 008672
+  description: Extra attention is needed
+- name: invalid
+  color: E4E669
+  description: This doesn't seem right
+- name: kubernetes
+  color: 2CF1BA
+  description: Container orchestration stuff
+- name: pip
+  color: 2E79F8
+  description: Pull requests that update a dependency file
+- name: prod
+  color: 2D13F1
+  description: Production environment
+- name: python
+  color: 006B75
+  description: Pull requests that update a dependency file
+- name: question
+  color: D876E3
+  description: Further information is requested
+- name: service
+  color: 3EFA45
+  description: Kubernetes service configuration
+- name: task
+  color: EEFF00
+  description: New task
+- name: wontfix
+  color: FBCA04
+  description: This will not be worked on
+
+# Application labels
+- name: k3s-hello-mdsanima
+  color: 0052CC
+  description: Docker image application
+- name: k3s-hello-world
+  color: 006b75
+  description: Docker image application

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,35 @@
+# Copyright (c) 2023-2024 MDSANIMA DEV. All rights reserved.
+# Licensed under the MIT license.
+
+# This file is used for syncing GitHub repository labels defined in the `.github/labels.yml` file.
+# Documentation: https://github.com/Financial-Times/github-label-sync/#label-config-file
+
+# Workflow setup
+name: Sync Labels
+
+on:
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/labels.yml
+      - .github/workflows/labels.yml
+
+jobs:
+  sync-labels:
+    name: Sync Labels
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Syncing labels
+        uses: crazy-max/ghaction-github-labeler@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          yaml-file: .github/labels.yml


### PR DESCRIPTION
Added generic and application labels.

For the **Sync Labels**, added the workflow that runs monthly and on a push to the main branch for specific files configured in GitHub Action.